### PR TITLE
CityGML 3.0: Add support for spaces (+ new transportation)

### DIFF
--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -73,6 +73,18 @@ namespace citygml {
            	// ADD Buildding model 
 			COT_IntBuildingInstallation		= 1ll<< 34,
 
+            COT_GenericOccupiedSpace        = 1ll<< 40,
+            COT_GenericUnoccupiedSpace      = 1ll<< 41,
+            COT_GenericLogicalSpace         = 1ll<< 42,
+            COT_GenericThematicSurface      = 1ll<< 43,
+            COT_TrafficSpace                = 1ll<< 44,
+            COT_AuxiliaryTrafficSpace       = 1ll<< 45,
+            COT_Intersection                = 1ll<< 46,
+            COT_Section                     = 1ll<< 47,
+            COT_Waterway                    = 1ll<< 48,
+            COT_BuildingConstructiveElement = 1ll<< 49,
+            COT_BuildingRoom = 1ll<< 50,
+
             COT_All                         = 0xFFFFFFFFFFFFFFFFll
         };
 

--- a/sources/include/parser/nodetypes.h
+++ b/sources/include/parser/nodetypes.h
@@ -62,6 +62,8 @@ namespace citygml {
         NODETYPE( CORE, MimeType)
         NODETYPE( CORE, LibraryObject)
 
+        NODETYPE( CORE, Boundary )
+
         // GRP
         NODETYPE( GRP, CityObjectGroup )
         NODETYPE( GRP, GroupMember )
@@ -98,6 +100,22 @@ namespace citygml {
         NODETYPE( GEN, Lod2ImplicitRepresentation )
         NODETYPE( GEN, Lod3ImplicitRepresentation )
         NODETYPE( GEN, Lod4ImplicitRepresentation )
+
+        NODETYPE( GEN, GenericOccupiedSpace )
+        NODETYPE( GEN, GenericUnoccupiedSpace )
+        NODETYPE( GEN, GenericLogicalSpace )
+        NODETYPE( GEN, GenericThematicSurface )
+
+        NODETYPE( GEN, Lod0MultiCurve )
+        NODETYPE( GEN, Lod2MultiCurve )
+        NODETYPE( GEN, Lod3MultiCurve )
+        NODETYPE( GEN, Lod0MultiSurface )
+        NODETYPE( GEN, Lod2MultiSurface )
+        NODETYPE( GEN, Lod3MultiSurface )
+
+        NODETYPE( GEN, Area )
+        NODETYPE( GEN, SpaceType )
+        NODETYPE( GEN, Volume )
 
         // TEX
         // NODETYPE( GML, TexturedSurface ) // Deprecated
@@ -215,6 +233,8 @@ namespace citygml {
         NODETYPE( BLDG, OuterFloorSurface )
         NODETYPE( BLDG, BuildingFurniture )
         NODETYPE( BLDG, IntBuildingInstallation)
+        NODETYPE( BLDG, BuildingConstructiveElement)
+        NODETYPE( BLDG, BuildingRoom)
             
         NODETYPE( BLDG, CityFurniture )
         NODETYPE( BLDG, Address)
@@ -299,14 +319,20 @@ namespace citygml {
         NODETYPE( TRANS, TransportationComplex )
         NODETYPE( TRANS, TrafficArea )
         NODETYPE( TRANS, AuxiliaryTrafficArea )
+        NODETYPE( TRANS, TrafficSpace )
+        NODETYPE( TRANS, AuxiliaryTrafficSpace )
         NODETYPE( TRANS, Track )
         NODETYPE( TRANS, Road )
         NODETYPE( TRANS, Railway )
         NODETYPE( TRANS, Square )
+        NODETYPE( TRANS, Intersection )
+        NODETYPE( TRANS, Section )
+        NODETYPE( TRANS, Waterway )
 
         NODETYPE( TRANS, Usage )
         NODETYPE( TRANS, Function )
         NODETYPE( TRANS, SurfaceMaterial )
+        NODETYPE( TRANS, Granularity )
 
         NODETYPE( TRANS, Lod0Network )
         NODETYPE( TRANS, Lod1MultiSurface )

--- a/sources/src/citygml/cityobject.cpp
+++ b/sources/src/citygml/cityobject.cpp
@@ -169,6 +169,10 @@ namespace citygml {
             return "BuildingInstallation";
         case CityObject::CityObjectsType::COT_BuildingFurniture:
             return "BuildingFurniture";
+        case CityObject::CityObjectsType::COT_BuildingConstructiveElement:
+            return "BuildingConstructiveElement";
+        case CityObject::CityObjectsType::COT_BuildingRoom:
+            return "BuildingRoom";
         case CityObject::CityObjectsType::COT_Door:
             return "Door";
         case CityObject::CityObjectsType::COT_Window:
@@ -183,6 +187,12 @@ namespace citygml {
             return "Railway";
         case CityObject::CityObjectsType::COT_Square:
             return "Square";
+        case CityObject::CityObjectsType::COT_Intersection:
+            return "Intersection";
+        case CityObject::CityObjectsType::COT_Section:
+            return "Section";
+        case CityObject::CityObjectsType::COT_Waterway:
+            return "Waterway";
         case CityObject::CityObjectsType::COT_PlantCover:
             return "PlantCover";
         case CityObject::CityObjectsType::COT_SolitaryVegetationObject:
@@ -226,7 +236,13 @@ namespace citygml {
         case CityObject::CityObjectsType::COT_TransportationObject:
             return "TransportationObject";
         case CityObject::CityObjectsType::COT_IntBuildingInstallation:
-	    return "IntBuildingInstallation";
+	        return "IntBuildingInstallation";
+        case CityObject::CityObjectsType::COT_GenericOccupiedSpace:
+	        return "GenericOccupiedSpace";
+        case CityObject::CityObjectsType::COT_GenericUnoccupiedSpace:
+	        return "GenericUnoccupiedSpace";
+        case CityObject::CityObjectsType::COT_GenericLogicalSpace:
+	        return "GenericLogicalSpace";
         default:
             return "Unknown";
         }
@@ -244,6 +260,8 @@ namespace citygml {
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Room), CityObject::CityObjectsType::COT_Room},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_BuildingInstallation), CityObject::CityObjectsType::COT_BuildingInstallation},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_BuildingFurniture), CityObject::CityObjectsType::COT_BuildingFurniture},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_BuildingConstructiveElement), CityObject::CityObjectsType::COT_BuildingConstructiveElement},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_BuildingRoom), CityObject::CityObjectsType::COT_BuildingRoom},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Door), CityObject::CityObjectsType::COT_Door},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Window), CityObject::CityObjectsType::COT_Window},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_CityFurniture), CityObject::CityObjectsType::COT_CityFurniture},
@@ -251,6 +269,9 @@ namespace citygml {
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Road), CityObject::CityObjectsType::COT_Road},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Railway), CityObject::CityObjectsType::COT_Railway},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Square), CityObject::CityObjectsType::COT_Square},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Intersection), CityObject::CityObjectsType::COT_Intersection},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Section), CityObject::CityObjectsType::COT_Section},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_Waterway), CityObject::CityObjectsType::COT_Waterway},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_PlantCover), CityObject::CityObjectsType::COT_PlantCover},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_SolitaryVegetationObject), CityObject::CityObjectsType::COT_SolitaryVegetationObject},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_WaterBody), CityObject::CityObjectsType::COT_WaterBody},
@@ -272,7 +293,10 @@ namespace citygml {
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_OuterCeilingSurface), CityObject::CityObjectsType::COT_OuterCeilingSurface},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_OuterFloorSurface), CityObject::CityObjectsType::COT_OuterFloorSurface},
          {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_TransportationObject), CityObject::CityObjectsType::COT_TransportationObject},
-	 {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_IntBuildingInstallation), CityObject::CityObjectsType::COT_IntBuildingInstallation}
+	     {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_IntBuildingInstallation), CityObject::CityObjectsType::COT_IntBuildingInstallation},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_GenericOccupiedSpace), CityObject::CityObjectsType::COT_GenericOccupiedSpace},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_GenericUnoccupiedSpace), CityObject::CityObjectsType::COT_GenericUnoccupiedSpace},
+         {cityObjectsTypeToLowerString(CityObject::CityObjectsType::COT_GenericLogicalSpace), CityObject::CityObjectsType::COT_GenericLogicalSpace}
     };
 
     CityObject::CityObjectsType cityObjectsTypeFromString(const std::string& s, bool& valid)

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -56,11 +56,17 @@ namespace citygml {
 
             if (!typeIDTypeMapInitialized) {
                 typeIDTypeMap.insert(HANDLE_TYPE(GEN, GenericCityObject));
+                typeIDTypeMap.insert(HANDLE_TYPE(GEN, GenericOccupiedSpace));
+                typeIDTypeMap.insert(HANDLE_TYPE(GEN, GenericUnoccupiedSpace));
+                typeIDTypeMap.insert(HANDLE_TYPE(GEN, GenericLogicalSpace));
+                typeIDTypeMap.insert(HANDLE_TYPE(GEN, GenericThematicSurface));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, Building));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, BuildingPart));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, Room));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, BuildingInstallation));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, BuildingFurniture));
+                typeIDTypeMap.insert(HANDLE_TYPE(BLDG, BuildingConstructiveElement));
+                typeIDTypeMap.insert(HANDLE_TYPE(BLDG, BuildingRoom));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, Door));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, Window));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, CityFurniture));
@@ -69,9 +75,14 @@ namespace citygml {
                 typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Road));
                 typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Railway));
                 typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Square));
+                typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Intersection));
+                typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Section));
+                typeIDTypeMap.insert(HANDLE_TYPE(TRANS, Waterway));
                 typeIDTypeMap.insert(HANDLE_GROUP_TYPE(TRANS, TransportationComplex, CityObject::CityObjectsType::COT_TransportationObject));
                 typeIDTypeMap.insert(HANDLE_GROUP_TYPE(TRANS, TrafficArea, CityObject::CityObjectsType::COT_TransportationObject));
                 typeIDTypeMap.insert(HANDLE_GROUP_TYPE(TRANS, AuxiliaryTrafficArea, CityObject::CityObjectsType::COT_TransportationObject));
+                typeIDTypeMap.insert(HANDLE_TYPE(TRANS, TrafficSpace));
+                typeIDTypeMap.insert(HANDLE_TYPE(TRANS, AuxiliaryTrafficSpace));
                 typeIDTypeMap.insert(HANDLE_TYPE(VEG, PlantCover));
                 typeIDTypeMap.insert(HANDLE_TYPE(VEG, SolitaryVegetationObject));
                 typeIDTypeMap.insert(HANDLE_TYPE(WTR, WaterBody));
@@ -143,6 +154,9 @@ namespace citygml {
                 attributesSet.insert(HANDLE_ATTR(GEN, Class));
                 attributesSet.insert(HANDLE_ATTR(GEN, Function));
                 attributesSet.insert(HANDLE_ATTR(GEN, Usage));
+                attributesSet.insert(HANDLE_ATTR(GEN, Area));
+                attributesSet.insert(HANDLE_ATTR(GEN, SpaceType));
+                attributesSet.insert(HANDLE_ATTR(GEN, Volume));
                 attributesSet.insert(HANDLE_ATTR(LUSE, Class));
                 attributesSet.insert(HANDLE_ATTR(LUSE, Function));
                 attributesSet.insert(HANDLE_ATTR(LUSE, Usage));
@@ -150,6 +164,7 @@ namespace citygml {
                 attributesSet.insert(HANDLE_ATTR(TRANS, Usage));
                 attributesSet.insert(HANDLE_ATTR(TRANS, Function));
                 attributesSet.insert(HANDLE_ATTR(TRANS, SurfaceMaterial));
+                attributesSet.insert(HANDLE_ATTR(TRANS, Granularity));
                 attributesSet.insert(HANDLE_ATTR(WTR, Class));
                 attributesSet.insert(HANDLE_ATTR(WTR, Function));
                 attributesSet.insert(HANDLE_ATTR(WTR, Usage));
@@ -185,6 +200,9 @@ namespace citygml {
                 attributeTypeMap[HANDLE_ATTR(GEN, Class)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(GEN, Function)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(GEN, Usage)] = AttributeType::String;
+                attributeTypeMap[HANDLE_ATTR(GEN, Area)] = AttributeType::String;
+                attributeTypeMap[HANDLE_ATTR(GEN, SpaceType)] = AttributeType::String;
+                attributeTypeMap[HANDLE_ATTR(GEN, Volume)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(LUSE, Class)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(LUSE, Function)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(LUSE, Usage)] = AttributeType::String;
@@ -192,6 +210,7 @@ namespace citygml {
                 attributeTypeMap[HANDLE_ATTR(TRANS, Usage)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(TRANS, Function)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(TRANS, SurfaceMaterial)] = AttributeType::String;
+                attributeTypeMap[HANDLE_ATTR(TRANS, Granularity)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(WTR, Class)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(WTR, Function)] = AttributeType::String;
                 attributeTypeMap[HANDLE_ATTR(WTR, Usage)] = AttributeType::String;
@@ -288,10 +307,18 @@ namespace citygml {
                    || node == NodeType::BLDG_InteriorRoomNode
                    || node == NodeType::BLDG_OpeningNode
                    || node == NodeType::BLDG_ConsistsOfBuildingPartNode
+                   || node == NodeType::BLDG_BuildingPartNode
+                   || node == NodeType::BLDG_BuildingConstructiveElementNode
+                   || node == NodeType::BLDG_BuildingRoomNode
                    || node == NodeType::GRP_GroupMemberNode
                    || node == NodeType::GRP_ParentNode
                    || node == NodeType::TRANS_TrafficAreaNode
                    || node == NodeType::TRANS_AuxiliaryTrafficAreaNode
+                   || node == NodeType::TRANS_TrafficSpaceNode
+                   || node == NodeType::TRANS_AuxiliaryTrafficSpaceNode
+                   || node == NodeType::TRANS_IntersectionNode
+                   || node == NodeType::TRANS_SectionNode
+                   || node == NodeType::TRANS_WaterwayNode
                    || node == NodeType::WTR_BoundedByNode
                    || node == NodeType::DEM_ReliefComponentNode
                    || node == NodeType::DEM_TINReliefNode
@@ -299,7 +326,12 @@ namespace citygml {
                    || node == NodeType::DEM_BreaklineReliefNode
                    || node == NodeType::DEM_RasterReliefNode
                    || node == NodeType::DEM_GridNode
-                   || node == NodeType::CORE_GeneralizesToNode) {
+                   || node == NodeType::CORE_GeneralizesToNode
+                   || node == NodeType::GEN_GenericOccupiedSpaceNode
+                   || node == NodeType::GEN_GenericUnoccupiedSpaceNode
+                   || node == NodeType::GEN_GenericLogicalSpaceNode
+                   || node == NodeType::GEN_GenericThematicSurfaceNode
+                   || node == NodeType::CORE_BoundaryNode) {
             setParserForNextElement(new CityObjectElementParser(m_documentParser, m_factory, m_logger, [this](CityObject* obj) {
                                         m_model->addChildCityObject(obj);
                                     }));
@@ -352,7 +384,13 @@ namespace citygml {
                    || node == NodeType::LUSE_Lod2MultiSurfaceNode
                    || node == NodeType::TRANS_Lod2MultiSurfaceNode
                    || node == NodeType::WTR_Lod2SolidNode
-                   || node == NodeType::WTR_Lod2SurfaceNode) {
+                   || node == NodeType::WTR_Lod2SurfaceNode
+                   || node == NodeType::GEN_Lod0MultiCurveNode
+                   || node == NodeType::GEN_Lod2MultiCurveNode
+                   || node == NodeType::GEN_Lod3MultiCurveNode
+                   || node == NodeType::GEN_Lod0MultiSurfaceNode
+                   || node == NodeType::GEN_Lod2MultiSurfaceNode
+                   || node == NodeType::GEN_Lod3MultiSurfaceNode) {
 
             parseGeometryForLODLevel(2);
         } else if (node == NodeType::BLDG_Lod3MultiCurveNode
@@ -512,6 +550,9 @@ namespace citygml {
                     || node == NodeType::BLDG_Lod4MultiSurfaceNode
                     || node == NodeType::BLDG_Lod4SolidNode
                     || node == NodeType::BLDG_Lod4TerrainIntersectionNode
+                    || node == NodeType::BLDG_BuildingPartNode
+                    || node == NodeType::BLDG_BuildingConstructiveElementNode
+                    || node == NodeType::BLDG_BuildingRoomNode
                     || node == NodeType::GEN_Lod1GeometryNode
                     || node == NodeType::GEN_Lod2GeometryNode
                     || node == NodeType::GEN_Lod3GeometryNode
@@ -566,6 +607,11 @@ namespace citygml {
                     || node == NodeType::TRANS_Lod0NetworkNode
                     || node == NodeType::TRANS_TrafficAreaNode
                     || node == NodeType::TRANS_AuxiliaryTrafficAreaNode
+                    || node == NodeType::TRANS_TrafficSpaceNode
+                    || node == NodeType::TRANS_AuxiliaryTrafficSpaceNode
+                    || node == NodeType::TRANS_IntersectionNode
+                    || node == NodeType::TRANS_SectionNode
+                    || node == NodeType::TRANS_WaterwayNode
                     || node == NodeType::TRANS_Lod1MultiSurfaceNode
                     || node == NodeType::TRANS_Lod2MultiSurfaceNode
                     || node == NodeType::TRANS_Lod3MultiSurfaceNode
@@ -584,7 +630,18 @@ namespace citygml {
                     || node == NodeType::WTR_BoundedByNode
                     || node == NodeType::BLDG_AddressNode
                     || node == NodeType::CORE_AddressNode
-                    || node == NodeType::CORE_XalAddressNode) {
+                    || node == NodeType::CORE_XalAddressNode
+                    || node == NodeType::GEN_GenericOccupiedSpaceNode
+                    || node == NodeType::GEN_GenericUnoccupiedSpaceNode
+                    || node == NodeType::GEN_GenericLogicalSpaceNode
+                    || node == NodeType::GEN_GenericThematicSurfaceNode
+                    || node == NodeType::GEN_Lod0MultiCurveNode
+                    || node == NodeType::GEN_Lod2MultiCurveNode
+                    || node == NodeType::GEN_Lod3MultiCurveNode
+                    || node == NodeType::GEN_Lod0MultiSurfaceNode
+                    || node == NodeType::GEN_Lod2MultiSurfaceNode
+                    || node == NodeType::GEN_Lod3MultiSurfaceNode
+                    || node == NodeType::CORE_BoundaryNode) {
 
             return true;
         }

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -105,6 +105,8 @@ namespace citygml {
                 INITIALIZE_NODE( CORE, MimeType)
                 INITIALIZE_NODE( CORE, LibraryObject)
 
+                INITIALIZE_NODE( CORE, Boundary)
+
                 // GRP
                 INITIALIZE_NODE( GRP, CityObjectGroup )
                 INITIALIZE_NODE( GRP, GroupMember )
@@ -141,6 +143,15 @@ namespace citygml {
                 INITIALIZE_NODE( GEN, Lod2ImplicitRepresentation )
                 INITIALIZE_NODE( GEN, Lod3ImplicitRepresentation )
                 INITIALIZE_NODE( GEN, Lod4ImplicitRepresentation )
+
+                INITIALIZE_NODE( GEN, GenericOccupiedSpace )
+                INITIALIZE_NODE( GEN, GenericUnoccupiedSpace )
+                INITIALIZE_NODE( GEN, GenericLogicalSpace )
+                INITIALIZE_NODE( GEN, GenericThematicSurface )
+
+                INITIALIZE_NODE( GEN, Area )
+                INITIALIZE_NODE( GEN, SpaceType )
+                INITIALIZE_NODE( GEN, Volume )
 
                 // TEX
                 // INITIALIZE_NODE( GML, TexturedSurface ) // Deprecated
@@ -271,6 +282,8 @@ namespace citygml {
                 INITIALIZE_NODE( BLDG, BuildingFurniture )
                 INITIALIZE_NODE( BLDG, RoofType)
                 INITIALIZE_NODE( BLDG, IntBuildingInstallation)
+                INITIALIZE_NODE( BLDG, BuildingConstructiveElement)
+                INITIALIZE_NODE( BLDG, BuildingRoom)
 
                 INITIALIZE_NODE( BLDG, CityFurniture )
 
@@ -338,14 +351,20 @@ namespace citygml {
                 INITIALIZE_NODE( TRANS, TransportationComplex )
                 INITIALIZE_NODE( TRANS, TrafficArea )
                 INITIALIZE_NODE( TRANS, AuxiliaryTrafficArea )
+                INITIALIZE_NODE( TRANS, TrafficSpace )
+                INITIALIZE_NODE( TRANS, AuxiliaryTrafficSpace )
                 INITIALIZE_NODE( TRANS, Track )
                 INITIALIZE_NODE( TRANS, Road )
                 INITIALIZE_NODE( TRANS, Railway )
                 INITIALIZE_NODE( TRANS, Square )
+                INITIALIZE_NODE( TRANS, Intersection )
+                INITIALIZE_NODE( TRANS, Section )
+                INITIALIZE_NODE( TRANS, Waterway )
 
                 INITIALIZE_NODE( TRANS, Usage )
                 INITIALIZE_NODE( TRANS, Function )
                 INITIALIZE_NODE( TRANS, SurfaceMaterial )
+                INITIALIZE_NODE( TRANS, Granularity )
 
                 INITIALIZE_NODE( TRANS, Lod0Network )
                 INITIALIZE_NODE( TRANS, Lod1MultiSurface )
@@ -486,6 +505,8 @@ namespace citygml {
     DEFINE_NODE( CORE, MimeType)
     DEFINE_NODE( CORE, LibraryObject)
 
+    DEFINE_NODE( CORE, Boundary)
+
     // GRP
     DEFINE_NODE( GRP, CityObjectGroup )
     DEFINE_NODE( GRP, GroupMember )
@@ -522,6 +543,22 @@ namespace citygml {
     DEFINE_NODE( GEN, Lod2ImplicitRepresentation )
     DEFINE_NODE( GEN, Lod3ImplicitRepresentation )
     DEFINE_NODE( GEN, Lod4ImplicitRepresentation )
+
+    DEFINE_NODE( GEN, GenericOccupiedSpace )
+    DEFINE_NODE( GEN, GenericUnoccupiedSpace )
+    DEFINE_NODE( GEN, GenericLogicalSpace )
+    DEFINE_NODE( GEN, GenericThematicSurface )
+
+    DEFINE_NODE( GEN, Lod0MultiCurve )
+    DEFINE_NODE( GEN, Lod2MultiCurve )
+    DEFINE_NODE( GEN, Lod3MultiCurve )
+    DEFINE_NODE( GEN, Lod0MultiSurface )
+    DEFINE_NODE( GEN, Lod2MultiSurface )
+    DEFINE_NODE( GEN, Lod3MultiSurface )
+
+    DEFINE_NODE( GEN, Area )
+    DEFINE_NODE( GEN, SpaceType )
+    DEFINE_NODE( GEN, Volume )
 
     // TEX
     // DEFINE_NODE( GML, TexturedSurface ) // Deprecated
@@ -656,7 +693,9 @@ namespace citygml {
     DEFINE_NODE( BLDG, BuildingFurniture )
     DEFINE_NODE( BLDG, RoofType)
     DEFINE_NODE( BLDG, IntBuildingInstallation)
-        
+    DEFINE_NODE( BLDG, BuildingConstructiveElement)
+    DEFINE_NODE( BLDG, BuildingRoom)
+
     DEFINE_NODE( BLDG, CityFurniture )
 
     DEFINE_NODE( BLDG, Address)
@@ -724,14 +763,20 @@ namespace citygml {
     DEFINE_NODE( TRANS, TransportationComplex )
     DEFINE_NODE( TRANS, TrafficArea )
     DEFINE_NODE( TRANS, AuxiliaryTrafficArea )
+    DEFINE_NODE( TRANS, TrafficSpace )
+    DEFINE_NODE( TRANS, AuxiliaryTrafficSpace )
     DEFINE_NODE( TRANS, Track )
     DEFINE_NODE( TRANS, Road )
     DEFINE_NODE( TRANS, Railway )
     DEFINE_NODE( TRANS, Square )
+    DEFINE_NODE( TRANS, Intersection )
+    DEFINE_NODE( TRANS, Section )
+    DEFINE_NODE( TRANS, Waterway )
 
     DEFINE_NODE( TRANS, Usage )
     DEFINE_NODE( TRANS, Function )
     DEFINE_NODE( TRANS, SurfaceMaterial )
+    DEFINE_NODE( TRANS, Granularity )
 
     DEFINE_NODE( TRANS, Lod0Network )
     DEFINE_NODE( TRANS, Lod1MultiSurface )


### PR DESCRIPTION
Add support for spaces: https://docs.ogc.org/guides/20-066.html#ug-coremodel-section
and new related transportation nodes.

**Main additions:**
- [gen:GenericOccupiedSpace](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/generics/#element_GenericOccupiedSpace)
  - [sample model](https://github.com/catenda/libcitygml/files/14666295/cube.city.zip)
- [gen:GenericUnoccupiedSpace](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/generics/#element_GenericUnoccupiedSpace)
- [gen:GenericLogicalSpace](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/generics/#element_GenericLogicalSpace)
- [tran:Intersection](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/transportation/#element_Intersection)
- [tran:Section](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/transportation/#element_Section)
- [tran:Waterway](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/transportation/#element_Waterway)
- [bldg:buildingConstructiveElement](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/building/#element_BuildingConstructiveElement)
  - [sample model](https://github.com/tum-gis/ifc-to-citygml3/blob/master/output/FZK-Haus_CityGML3.gml)
- [bldg:buildingRoom](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/building/#element_BuildingRoom)
  - [sample model](https://github.com/tum-gis/ifc-to-citygml3/blob/master/output/FZK-Haus_CityGML3.gml)

**Fixes:**
- Call `setParserForNextElement` for `BLDG_BuildingPartNode`
  - Fixes "<bldg:buildingPart>" being ignored when occurring directly under a "<bldg:Building>"

**Models fixed by this PR:**
- [cube.city.zip](https://github.com/catenda/libcitygml/files/14666295/cube.city.zip)
- [DenHaag2.zip](https://github.com/catenda/libcitygml/files/14692660/DenHaag2.zip)
  - CityGML converted form CityJSON file from [this website](https://www.cityjson.org/datasets/), using citygml-tools
- [Rotterdam2.zip](https://github.com/catenda/libcitygml/files/14692668/Rotterdam2.zip)
  - CityGML converted form CityJSON file from [this website](https://www.cityjson.org/datasets/), using citygml-tools
- CityGML 3.0 dataset for Rotterdam, from [here](https://1drv.ms/u/s!Ag_9VT-F89-7jlqoc77pjKmG-8VP?e=G551gC)
- CityGML 3.0 dataset for Helsinki, from [here](https://1drv.ms/u/s!Ag_9VT-F89-7jlqoc77pjKmG-8VP?e=G551gC)
- CityGML 3.0 dataset for Espoo, from [here](https://1drv.ms/u/s!Ag_9VT-F89-7jlqoc77pjKmG-8VP?e=G551gC)
- https://github.com/tum-gis/citygml3.0-transportation-examples/blob/master/Simple%20Intersection/data/cityGML3_transportation_simpleIntersection.gml
- https://github.com/tum-gis/citygml3.0-transportation-examples/blob/master/Streetspace%20Model%20of%20New%20York%20City/data/CityGML3_Transportation_NYC.zip

