### PR TITLE
RelativeGeometry, Con:FillingSurface + others

### DIFF
--- a/sources/include/citygml/cityobject.h
+++ b/sources/include/citygml/cityobject.h
@@ -83,7 +83,10 @@ namespace citygml {
             COT_Section                     = 1ll<< 47,
             COT_Waterway                    = 1ll<< 48,
             COT_BuildingConstructiveElement = 1ll<< 49,
-            COT_BuildingRoom = 1ll<< 50,
+            COT_BuildingRoom                = 1ll<< 50,
+            COT_FillingSurface              = 1ll<< 51,
+            COT_WindowSurface               = 1ll<< 52,
+            COT_DoorSurface                 = 1ll<< 53,
 
             COT_All                         = 0xFFFFFFFFFFFFFFFFll
         };

--- a/sources/include/parser/nodetypes.h
+++ b/sources/include/parser/nodetypes.h
@@ -63,6 +63,7 @@ namespace citygml {
         NODETYPE( CORE, LibraryObject)
 
         NODETYPE( CORE, Boundary )
+        NODETYPE( CORE, RelativeGeometry )
 
         // GRP
         NODETYPE( GRP, CityObjectGroup )
@@ -220,6 +221,10 @@ namespace citygml {
         NODETYPE( BLDG, Lod3TerrainIntersection )
         NODETYPE( BLDG, Lod4TerrainIntersection )
         NODETYPE( BLDG, ConsistsOfBuildingPart )
+
+        NODETYPE( CON, FillingSurface )
+        NODETYPE( CON, WindowSurface )
+        NODETYPE( CON, DoorSurface )
 
         // BoundarySurfaceType
         NODETYPE( BLDG, WallSurface )

--- a/sources/src/parser/cityobjectelementparser.cpp
+++ b/sources/src/parser/cityobjectelementparser.cpp
@@ -95,6 +95,9 @@ namespace citygml {
                 typeIDTypeMap.insert(HANDLE_TYPE(BRID, BridgeConstructionElement));
                 typeIDTypeMap.insert(HANDLE_TYPE(BRID, BridgeInstallation));
                 typeIDTypeMap.insert(HANDLE_TYPE(BRID, BridgePart));
+                typeIDTypeMap.insert(HANDLE_TYPE(CON, FillingSurface));
+                typeIDTypeMap.insert(HANDLE_TYPE(CON, WindowSurface));
+                typeIDTypeMap.insert(HANDLE_TYPE(CON, DoorSurface));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, WallSurface));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, RoofSurface));
                 typeIDTypeMap.insert(HANDLE_TYPE(BLDG, GroundSurface));
@@ -310,6 +313,7 @@ namespace citygml {
                    || node == NodeType::BLDG_BuildingPartNode
                    || node == NodeType::BLDG_BuildingConstructiveElementNode
                    || node == NodeType::BLDG_BuildingRoomNode
+                   || node == NodeType::BLDG_BuildingInstallationNode
                    || node == NodeType::GRP_GroupMemberNode
                    || node == NodeType::GRP_ParentNode
                    || node == NodeType::TRANS_TrafficAreaNode
@@ -331,7 +335,10 @@ namespace citygml {
                    || node == NodeType::GEN_GenericUnoccupiedSpaceNode
                    || node == NodeType::GEN_GenericLogicalSpaceNode
                    || node == NodeType::GEN_GenericThematicSurfaceNode
-                   || node == NodeType::CORE_BoundaryNode) {
+                   || node == NodeType::CORE_BoundaryNode
+                   || node == NodeType::CON_FillingSurfaceNode
+                   || node == NodeType::CON_WindowSurfaceNode
+                   || node == NodeType::CON_DoorSurfaceNode) {
             setParserForNextElement(new CityObjectElementParser(m_documentParser, m_factory, m_logger, [this](CityObject* obj) {
                                         m_model->addChildCityObject(obj);
                                     }));
@@ -553,6 +560,10 @@ namespace citygml {
                     || node == NodeType::BLDG_BuildingPartNode
                     || node == NodeType::BLDG_BuildingConstructiveElementNode
                     || node == NodeType::BLDG_BuildingRoomNode
+                    || node == NodeType::BLDG_BuildingInstallationNode
+                    || node == NodeType::CON_FillingSurfaceNode
+                    || node == NodeType::CON_WindowSurfaceNode
+                    || node == NodeType::CON_DoorSurfaceNode
                     || node == NodeType::GEN_Lod1GeometryNode
                     || node == NodeType::GEN_Lod2GeometryNode
                     || node == NodeType::GEN_Lod3GeometryNode

--- a/sources/src/parser/implicitgeometryelementparser.cpp
+++ b/sources/src/parser/implicitgeometryelementparser.cpp
@@ -121,8 +121,6 @@ namespace citygml {
                 m_factory.requestSharedGeometryWithID(m_model, sharedGeomID);
             } else {
 
-                std::string id = attributes.getCityGMLIDAttribute();
-
                 setParserForNextElement(new GeometryElementParser(m_documentParser, m_factory, m_logger, m_lodLevel, m_parentType, [this](Geometry* geom) {
                     m_model->addGeometry(m_factory.shareGeometry(geom));
                 }));

--- a/sources/src/parser/implicitgeometryelementparser.cpp
+++ b/sources/src/parser/implicitgeometryelementparser.cpp
@@ -113,6 +113,21 @@ namespace citygml {
                 }));
             }
             return true;
+        } else if (node == NodeType::CORE_RelativeGeometryNode) {
+
+            if (attributes.hasXLinkAttribute()) {
+
+                std::string sharedGeomID = attributes.getXLinkValue();
+                m_factory.requestSharedGeometryWithID(m_model, sharedGeomID);
+            } else {
+
+                std::string id = attributes.getCityGMLIDAttribute();
+
+                setParserForNextElement(new GeometryElementParser(m_documentParser, m_factory, m_logger, m_lodLevel, m_parentType, [this](Geometry* geom) {
+                    m_model->addGeometry(m_factory.shareGeometry(geom));
+                }));
+            }
+            return true;
         } else if (node == NodeType::CORE_LibraryObjectNode) {
             CITYGML_LOG_INFO(m_logger, "Skipping ImplicitGeometry child element <" << node  << ">  at " << getDocumentLocation() << " (Currently not supported!)");
             setParserForNextElement(new SkipElementParser(m_documentParser, m_logger));
@@ -139,6 +154,7 @@ namespace citygml {
             m_model->setReferencePoint(parseValue<TVec3d>(characters, m_logger, getDocumentLocation()));
             return true;
         } else if (   node == NodeType::CORE_RelativeGMLGeometryNode
+                   || node == NodeType::CORE_RelativeGeometryNode
                    || node == NodeType::GML_PointNode
                    || node == NodeType::CORE_ReferencePointNode
                    || node == NodeType::GML_ReferencePointNode

--- a/sources/src/parser/nodetypes.cpp
+++ b/sources/src/parser/nodetypes.cpp
@@ -106,6 +106,7 @@ namespace citygml {
                 INITIALIZE_NODE( CORE, LibraryObject)
 
                 INITIALIZE_NODE( CORE, Boundary)
+                INITIALIZE_NODE( CORE, RelativeGeometry)
 
                 // GRP
                 INITIALIZE_NODE( GRP, CityObjectGroup )
@@ -268,6 +269,10 @@ namespace citygml {
                 INITIALIZE_NODE( FRN, Lod2ImplicitRepresentation )
                 INITIALIZE_NODE( FRN, Lod3ImplicitRepresentation )
                 INITIALIZE_NODE( FRN, Lod4ImplicitRepresentation )
+
+                INITIALIZE_NODE( CON, FillingSurface )
+                INITIALIZE_NODE( CON, WindowSurface )
+                INITIALIZE_NODE( CON, DoorSurface )
 
                 // BoundarySurfaceType
                 INITIALIZE_NODE( BLDG, WallSurface )
@@ -510,6 +515,7 @@ namespace citygml {
     DEFINE_NODE( CORE, LibraryObject)
 
     DEFINE_NODE( CORE, Boundary)
+    DEFINE_NODE( CORE, RelativeGeometry)
 
     // GRP
     DEFINE_NODE( GRP, CityObjectGroup )
@@ -683,6 +689,10 @@ namespace citygml {
     DEFINE_NODE( FRN, Lod2ImplicitRepresentation )
     DEFINE_NODE( FRN, Lod3ImplicitRepresentation )
     DEFINE_NODE( FRN, Lod4ImplicitRepresentation )
+
+    DEFINE_NODE( CON, FillingSurface )
+    DEFINE_NODE( CON, WindowSurface )
+    DEFINE_NODE( CON, DoorSurface )
 
     // BoundarySurfaceType
     DEFINE_NODE( BLDG, WallSurface )


### PR DESCRIPTION
CityGML 3.0 adds "relativeGeometry" to [ImplicitGeometry](https://opengeospatial.github.io/CityGML-3.0Encodings/xsd-doc/3.0/core/#type_ImplicitGeometryType).

In this PR I added support for this, in addition to:
- Con:FillingSurface
- Con:WindowSurface
- Con:DoorSurface
- Handle BuildingInstallation child element